### PR TITLE
Fix icon not showing up on BBB button

### DIFF
--- a/zimlet/tk_barrydegraaff_bigbluebutton/tk_barrydegraaff_bigbluebutton.js
+++ b/zimlet/tk_barrydegraaff_bigbluebutton/tk_barrydegraaff_bigbluebutton.js
@@ -220,7 +220,7 @@ BigBlueButton.prototype._initCalendarBigBlueButtonToolbar = function(toolbar, co
    var zimletInstance = appCtxt._zimletMgr.getZimletByName('tk_barrydegraaff_bigbluebutton').handlerObject;
 	if (!toolbar.getButton("BIGBLUEBUTTON2")) {
 		var buttonIndex = toolbar.opList.length + 1;
-		var button = toolbar.createOp("BIGBLUEBUTTON2", {image:"tk_barrydegraaff_bigbluebutton-panelIcon", text:"BigBlueButton", index:buttonIndex});
+		var button = toolbar.createOp("BIGBLUEBUTTON2", {image:"tk_barrydegraaff_bigbluebutton-panelIcon", text:"BigBlueButton", index:buttonIndex, showImageInToolbar:true, showTextInToolbar:true});
 		toolbar.addOp("BIGBLUEBUTTON2", buttonIndex);
 
 		var menu = new ZmPopupMenu(button); //create menu


### PR DESCRIPTION
Hello Barry,

We found out that we could provide better visibility to BBB button / drop down menu by having the BB icon showing up in front of the button name (based on /opt/zimbra/jetty_base/webapps/zimbra/js/zimbraMail/share/view/ZmButtonToolBar.js l. 174). Credits to my colleague Guillaume. :-)

![screenshot](https://github.com/Zimbra-Community/bigbluebutton-zimlet/assets/11542051/4ebed7a2-af26-4b2c-bf48-4124a488efc5)